### PR TITLE
Python server for Open App functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ salesforcedx.sh
 .vscode
 mdapiout
 test.yml
+setup.sh

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python server.py

--- a/app.json
+++ b/app.json
@@ -2,23 +2,26 @@
   "name": "salesforce-dx-pipeline-sample",
   "version": "0.0.1",
   "description": "Test application for the salesforce-dx-buildpack",
-  "repository": "https://github.com/wadewegner/salesforce-dx-pipeline-sample",
+  "repository": "https://github.com/feliperyan/salesforce-pipelines-demo-fryan",
   "author": "",
   "license": "ALv2",
   "bugs": {
-    "url": "https://github.com/wadewegner/salesforce-dx-pipeline-sample/issues"
+    "url": "https://github.com/feliperyan/salesforce-pipelines-demo-fryan/issues"
   },
   "homepage":
-    "https://github.com/wadewegner/salesforce-dx-pipeline-sample#readme",
+    "https://github.com/feliperyan/salesforce-pipelines-demo-fryan#readme",
   "dependencies": {},
   "devDependencies": {},
   "buildpacks": [
     {
-      "url": "https://github.com/heroku/salesforce-cli-buildpack#v3"
+      "url": "https://github.com/heroku/heroku-buildpack-python"  
     },
     {
-      "url": "https://github.com/heroku/salesforce-buildpack#v1"
-    }
+      "url": "https://github.com/heroku/salesforce-cli-buildpack#v3"
+    },  
+    {
+      "url": "https://github.com/feliperyan/salesforce-buildpack#fryan-allow-procfile"
+    }      
   ],
   "env": {
     "SFDX_DEV_HUB_AUTH_URL": {
@@ -28,6 +31,9 @@
       "required": true
     },
     "HEROKU_APP_NAME" : {
+      "required": true
+    },
+    "API_KEY_HEROKU" : {
       "required": true
     }
   },

--- a/app.json
+++ b/app.json
@@ -2,14 +2,14 @@
   "name": "salesforce-dx-pipeline-sample",
   "version": "0.0.1",
   "description": "Test application for the salesforce-dx-buildpack",
-  "repository": "https://github.com/feliperyan/salesforce-pipelines-demo-fryan",
+  "repository": "https://github.com/wadewegner/salesforce-dx-pipeline-sample",
   "author": "",
   "license": "ALv2",
   "bugs": {
-    "url": "https://github.com/feliperyan/salesforce-pipelines-demo-fryan/issues"
+    "url": "https://github.com/wadewegner/salesforce-dx-pipeline-sample/issues"
   },
   "homepage":
-    "https://github.com/feliperyan/salesforce-pipelines-demo-fryan#readme",
+    "https://github.com/wadewegner/salesforce-dx-pipeline-sample#readme",
   "dependencies": {},
   "devDependencies": {},
   "buildpacks": [

--- a/get_sfdx_auth_url.py
+++ b/get_sfdx_auth_url.py
@@ -1,0 +1,39 @@
+import requests
+
+def get_auth_url(api_key, app_name):
+    heroku_api_releases_list = 'https://api.heroku.com/apps/'+app_name+'/releases'
+
+    header_data = {}
+    header_data['Accept'] = 'application/vnd.heroku+json; version=3'
+    header_data['Authorization'] = 'Bearer '+api_key
+
+    release = ''
+    output_stream_url = ''
+
+    sfdx_scratchie_url = ''
+
+    print('Requesting: ' + heroku_api_releases_list)
+
+    r = requests.get(heroku_api_releases_list, headers=header_data)
+    if r.status_code == 200:
+        for i in r.json():
+            if i.get('output_stream_url', False):
+                output_stream_url = i['output_stream_url']
+    else:
+        return 'ERROR: calling Heroku API: '+str(r.json())
+
+    print('Requesting: ' + output_stream_url)  
+
+    r2 = requests.get(output_stream_url)
+    if r2.status_code == 200:
+        lines = r2.text.split('\n')
+        if len(lines) > 0:
+            for l in lines:
+                if 'following URL:' in l:
+                    sfdx_scratchie_url = l[l.index('https'):]
+            if sfdx_scratchie_url == '':
+                return 'ERROR: URL for ScratchOrg was not found in output_stream_url. Did you set "show-scratch-org-url: true" within sfdx.yml?'
+    else:
+        return 'ERROR: getting the output_stream_url from releases failed: '+str(r2.json())
+
+    return sfdx_scratchie_url

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2019.3.9
+chardet==3.0.4
+idna==2.8
+requests==2.21.0
+urllib3==1.24.1

--- a/server.py
+++ b/server.py
@@ -1,0 +1,33 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import os
+from get_sfdx_auth_url import *
+
+PORT_NUMBER = os.getenv('PORT', 8080)
+APP_NAME = os.getenv('HEROKU_APP_NAME', '')
+API_KEY_HEROKU = os.getenv('API_KEY_HEROKU', '')
+
+
+#This class will handles any incoming request from
+#the browser 
+class myHandler(BaseHTTPRequestHandler):
+    
+    #Handler for the GET requests
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-type','text/html')
+        self.end_headers()
+        
+        link = get_auth_url(API_KEY_HEROKU, APP_NAME)
+        payload = '<html><body><a href="' + link + '">link here</a></body></html>'
+        
+        self.wfile.write(bytes(payload, encoding='utf-8'))
+        return
+
+
+#Create a web server and define the handler to manage the
+#incoming request
+server = HTTPServer(('', int(PORT_NUMBER)), myHandler)
+print ('Started httpserver on port ' , PORT_NUMBER)
+
+#Wait forever for incoming htto requests
+server.serve_forever()

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,10 @@ set -o nounset    # fail on unset variables
 
 ### Declare values
 
+# Get your API key from your Profile settings on Heroku. Make sure this file is not
+# checked in to version control (it's listed in .gitignore)
+API_KEY_HEROKU=''
+
 # Create a unique var to append
 TICKS=$(echo $(date +%s | cut -b1-13))
 
@@ -103,6 +107,8 @@ heroku config:set SFDX_AUTH_URL=$stagingSfdxAuthUrl -a $HEROKU_STAGING_APP_NAME
 prodSfdxAuthUrl=$(sfdx force:org:display --verbose -u $PROD_USERNAME --json | jq -r .result.sfdxAuthUrl)
 heroku config:set SFDX_AUTH_URL=$prodSfdxAuthUrl -a $HEROKU_PROD_APP_NAME
 
+heroku config:set API_KEY_HEROKU=$API_KEY_HEROKU -a $HEROKU_DEV_APP_NAME
+
 # Add buildpacks to apps
 heroku buildpacks:add -i 1 https://github.com/heroku/salesforce-cli-buildpack#v3 -a $HEROKU_DEV_APP_NAME
 heroku buildpacks:add -i 1 https://github.com/heroku/salesforce-cli-buildpack#v3 -a $HEROKU_STAGING_APP_NAME
@@ -129,3 +135,4 @@ heroku ci:config:set -p $HEROKU_PIPELINE_NAME SFDX_INSTALL_PACKAGE_VERSION=true
 heroku ci:config:set -p $HEROKU_PIPELINE_NAME SFDX_CREATE_PACKAGE_VERSION=false
 heroku ci:config:set -p $HEROKU_PIPELINE_NAME SFDX_PACKAGE_NAME="$PACKAGE_NAME"
 heroku ci:config:set -p $HEROKU_PIPELINE_NAME HEROKU_APP_NAME="$HEROKU_APP_NAME"
+

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,11 @@
 {
   "packageDirectories": [
-    {
-      "path": "force-app",
-      "default": true,
-      "id": "0Ho6A0000004C9XSAU",
-      "versionNumber": "1.0.0.NEXT",
-      "versionName": "version name"
-    }
+      {
+          "path": "force-app",
+          "default": true
+      }
   ],
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "42.0"
+  "sourceApiVersion": "45.0"
 }

--- a/sfdx.yml
+++ b/sfdx.yml
@@ -1,10 +1,10 @@
 scratch-org-def: config/project-scratch-def.json
 assign-permset: false
 permset-name:
-run-apex-tests: true
+run-apex-tests: false
 apex-test-format: tap
 delete-scratch-org: false
-show-scratch-org-url: false
+show-scratch-org-url: true
 open-path: 
 import-data: false
 data-plans:


### PR DESCRIPTION
**TL;DR** = this in conjunction with another pull request lets you "Open App" on Heroku and see your Scratch org with the latest Pull Request.

**This is in relation to:** 
- https://github.com/heroku/salesforce-buildpack/issues/32
- https://github.com/heroku/salesforce-buildpack/pull/42

Does some hacky log parsing using Heroku API to acquire the output of the release phase for salesforce-buildpack.  It uses a simple Python server to get the Scratch Org login URL and place it as a clickable link.